### PR TITLE
Include only necessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.1",
   "description": "Reframe.js: responsive iframes for embedded content",
   "main": "dist/reframe.js",
+  "files": [
+    "src/styles",
+    "dist"
+  ],
   "scripts": {
     "test": "gulp test",
     "postpublish": "PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag $PACKAGE_VERSION && git push origin --tags"


### PR DESCRIPTION
The `files` field is the opposite of `.npmignore`. With this I'd normally only include the `dist` folder, but probably someone is interested in using the mixin directly. Related to https://github.com/dollarshaveclub/reframe.js/pull/7

## From

```
PATH                            SIZE      %   
.npmignore                      0 B       0%  
.babelrc                        36 B      0%  
src/styles/reframe.scss         61 B      0%  
.eslintrc.json                  68 B      1%  
dist/reframe.css                133 B     1%  
dist/_reframe.scss              185 B     1%  
dist/_reframe_mixin.scss        216 B     2%  
src/styles/_reframe_mixin.scss  216 B     2%  
.travis.yml                     331 B     3%  
bower.json                      398 B     3%  
.editorconfig                   543 B     4%  
src/tests/tests.js              604 B     5%  
rollup.config.js                650 B     5%  
gulpfile.js                     774 B     6%  
src/reframe.js                  941 B     7%  
LICENSE                         1.07 kB   8%  
dist/reframe.js                 1.19 kB   9%  
src/tests/index.html            1.56 kB   12% 
package.json                    1.58 kB   12% 
README.md                       2.41 kB   19% 
                                              
DIR                             SIZE      %   
src/styles/                     277 B     2%  
dist/                           1.73 kB   13% 
src/tests/                      2.16 kB   17% 
src/                            3.38 kB   26% 
.                               12.97 kB  100%

PKGFILES SUMMARY
Publishable Size                ~12.97 kB 
Number of Directories           5         
Number of Files                 20    
```

## To

```
PATH                            SIZE     %   
src/styles/reframe.scss         61 B     1%  
dist/reframe.css                133 B    2%  
dist/_reframe.scss              185 B    3%  
dist/_reframe_mixin.scss        216 B    3%  
src/styles/_reframe_mixin.scss  216 B    3%  
LICENSE                         1.07 kB  15% 
dist/reframe.js                 1.19 kB  17% 
package.json                    1.63 kB  23% 
README.md                       2.41 kB  34% 
                                             
DIR                             SIZE     %   
src/                            277 B    4%  
src/styles/                     277 B    4%  
dist/                           1.73 kB  24% 
.                               7.12 kB  100%

PKGFILES SUMMARY
Publishable Size                ~7.12 kB  
Number of Directories           4         
Number of Files                 9    
```

Summary by [pkgfiles](https://github.com/timoxley/pkgfiles)