### PR TITLE
Error fix - Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.

### DIFF
--- a/src/noframe.js
+++ b/src/noframe.js
@@ -16,13 +16,13 @@ export default function noframe(target, container) {
     const w = frame.offsetWidth;
     const styles = frame.style;
     let maxW = `${w}px`;
-    let parent;
-    // If a targeted <parent> element is defined
-    // and it should not be `null`
+    let parent = null;
+    // If a targeted container <element> is present in DOM
     if (typeof container !== 'undefined') {
-      parent = document.querySelector(container) || null;
+      // `parent` will be either <element> or `null`
+      parent = document.querySelector(container);
     }
-    // If container <element> is found
+    // If container <element> found
     if (parent) {
       // gets/sets the height/width ratio
       maxW = window.getComputedStyle(parent, null).getPropertyValue('max-width');

--- a/src/noframe.js
+++ b/src/noframe.js
@@ -19,7 +19,10 @@ export default function noframe(target, container) {
     let parent;
     // If a targeted <parent> element is defined
     // and it should not be `null`
-    parent = (typeof container !== 'undefined') ? document.querySelector(container) : null;
+    if (typeof container !== 'undefined') {
+      parent = document.querySelector(container) || null;
+    }
+    // If container <element> is found
     if (parent) {
       // gets/sets the height/width ratio
       maxW = window.getComputedStyle(parent, null).getPropertyValue('max-width');

--- a/src/noframe.js
+++ b/src/noframe.js
@@ -19,7 +19,7 @@ export default function noframe(target, container) {
     let parent;
     // If a targeted <parent> element is defined
     // and it should not be `null`
-    parent = document.querySelector(container) || null;
+    parent = (typeof container !== 'undefined') ? document.querySelector(container) : null;
     if (parent) {
       // gets/sets the height/width ratio
       maxW = window.getComputedStyle(parent, null).getPropertyValue('max-width');

--- a/src/noframe.js
+++ b/src/noframe.js
@@ -12,15 +12,16 @@ export default function noframe(target, container) {
   if (!('length' in frames)) frames = [frames];
   for (let i = 0; i < frames.length; i += 1) {
     const frame = frames[i];
-    let parent = frame.parentElement;
     const h = frame.offsetHeight;
     const w = frame.offsetWidth;
     const styles = frame.style;
     let maxW = `${w}px`;
-    if (typeof container !== 'undefined') {
+    let parent;
+    // If a targeted <parent> element is defined
+    // and it should not be `null`
+    parent = document.querySelector(container) || null;
+    if (parent) {
       // gets/sets the height/width ratio
-      // => if a targeted <parent> element is defined
-      parent = document.querySelector(container);
       maxW = window.getComputedStyle(parent, null).getPropertyValue('max-width');
       styles.width = '100%';
       // calc is needed here b/c the maxW measurement type is unknown
@@ -28,6 +29,7 @@ export default function noframe(target, container) {
     } else {
       // gets/sets the height/width ratio
       // => if a targeted <element> closest parent <element> is NOT defined
+      parent = frame.parentElement;
       let maxH;
       styles.display = 'block';
       styles.marginLeft = 'auto';

--- a/src/noframe.js
+++ b/src/noframe.js
@@ -12,18 +12,14 @@ export default function noframe(target, container) {
   if (!('length' in frames)) frames = [frames];
   for (let i = 0; i < frames.length; i += 1) {
     const frame = frames[i];
+    const isContainerElement = typeof container !== 'undefined' && document.querySelector(container);
+    const parent = isContainerElement ? document.querySelector(container) : frame.parentElement;
     const h = frame.offsetHeight;
     const w = frame.offsetWidth;
     const styles = frame.style;
     let maxW = `${w}px`;
-    let parent = null;
-    // If a targeted container <element> is present in DOM
-    if (typeof container !== 'undefined') {
-      // `parent` will be either <element> or `null`
-      parent = document.querySelector(container);
-    }
-    // If container <element> found
-    if (parent) {
+    // => If a targeted <container> element is defined
+    if (isContainerElement) {
       // gets/sets the height/width ratio
       maxW = window.getComputedStyle(parent, null).getPropertyValue('max-width');
       styles.width = '100%';
@@ -32,7 +28,6 @@ export default function noframe(target, container) {
     } else {
       // gets/sets the height/width ratio
       // => if a targeted <element> closest parent <element> is NOT defined
-      parent = frame.parentElement;
       let maxH;
       styles.display = 'block';
       styles.marginLeft = 'auto';


### PR DESCRIPTION
Hi @yowainwright,

Use case - 
`$('#ytplayer').noframe('.my-class');`

In above snippet when element with selector(.my-class) doesn't exist in DOM, in that case receiving error - 

Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.

Proposed solution - If parent element doesn't exists, defaults to `frame.parentElement`

This issue is fixed, please review PR and let me know if you want to suggest anything.

Thanks,
-Mohan
![screen shot 2018-03-13 at 7 06 58 pm](https://user-images.githubusercontent.com/3479822/37345552-3f4f13aa-26f3-11e8-8df8-50f621c15061.png)
 

 